### PR TITLE
Set up MariaDB connection with encrypted password

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.env
+node_modules/

--- a/README.md
+++ b/README.md
@@ -6,3 +6,20 @@ This repository contains a simple setup with a Node.js backend and a React front
 - **frontend/**: A minimal React application configured with webpack and Babel.
 
 Each folder contains its own `package.json` with the required dependencies and scripts.
+
+## Backend database configuration
+
+The backend expects a MariaDB database. Environment variables are loaded from
+an `.env` file. Copy `backend/.env.example` to `backend/.env` and fill in the
+values. The password is stored in encrypted form. To generate the required
+variables run:
+
+```bash
+node encryptPassword.js "yourPassword"
+```
+
+This will output `ENCRYPTION_KEY`, `IV` and `DB_PASSWORD_ENC` which you should
+place in `backend/.env` along with the database host and user values.
+
+When the server starts it will attempt to connect to the database and log the
+result.

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+DB_HOST=pathcosmos.iptime.org
+DB_PORT=33377
+DB_NAME=tmsbbs
+DB_USER=root
+DB_PASSWORD_ENC=<your encrypted password>
+ENCRYPTION_KEY=<base64 key>
+IV=<base64 iv>

--- a/backend/db.js
+++ b/backend/db.js
@@ -1,0 +1,38 @@
+require('dotenv').config();
+const mariadb = require('mariadb');
+const crypto = require('crypto');
+
+function decryptPassword(enc) {
+  if (!enc) return '';
+  const key = Buffer.from(process.env.ENCRYPTION_KEY, 'base64');
+  const iv = Buffer.from(process.env.IV, 'base64');
+  const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
+  let str = decipher.update(enc, 'base64', 'utf8');
+  str += decipher.final('utf8');
+  return str;
+}
+
+const password = decryptPassword(process.env.DB_PASSWORD_ENC);
+
+const pool = mariadb.createPool({
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT,
+  user: process.env.DB_USER,
+  password,
+  database: process.env.DB_NAME,
+});
+
+async function testConnection() {
+  let conn;
+  try {
+    conn = await pool.getConnection();
+    await conn.ping();
+    console.log('Database connection successful');
+  } catch (err) {
+    console.error('Database connection failed:', err.message);
+  } finally {
+    if (conn) conn.release();
+  }
+}
+
+module.exports = { pool, testConnection };

--- a/backend/encryptPassword.js
+++ b/backend/encryptPassword.js
@@ -1,0 +1,17 @@
+const crypto = require('crypto');
+
+const password = process.argv[2];
+if (!password) {
+  console.error('Usage: node encryptPassword.js <password>');
+  process.exit(1);
+}
+
+const key = crypto.randomBytes(32);
+const iv = crypto.randomBytes(16);
+const cipher = crypto.createCipheriv('aes-256-cbc', key, iv);
+let encrypted = cipher.update(password, 'utf8', 'base64');
+encrypted += cipher.final('base64');
+
+console.log('ENCRYPTION_KEY=' + key.toString('base64'));
+console.log('IV=' + iv.toString('base64'));
+console.log('DB_PASSWORD_ENC=' + encrypted);

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const { testConnection } = require('./db');
 const app = express();
 const PORT = process.env.PORT || 3001;
 
@@ -8,4 +9,5 @@ app.get('/', (req, res) => {
 
 app.listen(PORT, () => {
   console.log(`Backend listening on port ${PORT}`);
+  testConnection();
 });

--- a/backend/package.json
+++ b/backend/package.json
@@ -7,6 +7,8 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "mariadb": "^3.1.0",
+    "dotenv": "^16.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- ignore `.env` and `node_modules`
- add backend environment file example
- add MariaDB connection using encrypted password
- provide helper script to encrypt passwords
- document DB setup

## Testing
- `npm start` *(fails: Cannot find module 'express')*
- `npm install` *(fails: connect EHOSTUNREACH)*