### PR TITLE
Add automatic OAuth table creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,14 @@ place in `backend/.env` along with the database host and user values.
 
 When the server starts it will attempt to connect to the database and log the
 result.
+
+## OAuth table setup
+
+After configuring the database connection, the OAuth tables will be created automatically when the backend starts. You can also create them manually by running:
+
+```bash
+node src/db/createOAuthTables.js
+```
+
+This script reads `backend/src/db/oauth_tables.sql` and ensures the `oauth_users` and `oauth_tokens` tables exist. The same logic runs during server startup so the tables are present without an extra step.
+

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const { testConnection } = require('./db');
+const { createOAuthTables } = require('./src/db/createOAuthTables');
 const app = express();
 const PORT = process.env.PORT || 3001;
 
@@ -7,7 +8,17 @@ app.get('/', (req, res) => {
   res.send('Hello from backend!');
 });
 
-app.listen(PORT, () => {
-  console.log(`Backend listening on port ${PORT}`);
-  testConnection();
+async function start() {
+  await testConnection();
+  await createOAuthTables();
+
+  app.listen(PORT, () => {
+    console.log(`Backend listening on port ${PORT}`);
+  });
+}
+
+start().catch((err) => {
+  console.error('Failed to start server:', err.message);
+  process.exit(1);
 });
+

--- a/backend/src/db/createOAuthTables.js
+++ b/backend/src/db/createOAuthTables.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+const { pool } = require('./db');
+
+async function createOAuthTables() {
+  const sqlPath = path.join(__dirname, 'oauth_tables.sql');
+  const statements = fs.readFileSync(sqlPath, 'utf8')
+    .split(/;\s*\n/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  let conn;
+  try {
+    conn = await pool.getConnection();
+    for (const stmt of statements) {
+      await conn.query(stmt);
+    }
+    console.log('OAuth tables ensured');
+  } catch (err) {
+    console.error('Failed to create OAuth tables:', err.message);
+    throw err;
+  } finally {
+    if (conn) conn.release();
+  }
+}
+
+if (require.main === module) {
+  createOAuthTables()
+    .catch(() => process.exitCode = 1)
+    .finally(() => pool.end());
+}
+
+module.exports = { createOAuthTables };
+

--- a/backend/src/db/oauth_tables.sql
+++ b/backend/src/db/oauth_tables.sql
@@ -1,0 +1,17 @@
+-- Tables for OAuth support
+CREATE TABLE IF NOT EXISTS oauth_users (
+  id INT AUTO_INCREMENT PRIMARY KEY COMMENT 'Unique identifier for the user',
+  provider VARCHAR(50) NOT NULL COMMENT 'OAuth provider (e.g. google)',
+  provider_id VARCHAR(255) NOT NULL COMMENT 'ID from the provider',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT 'Record creation time'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='OAuth user information';
+
+CREATE TABLE IF NOT EXISTS oauth_tokens (
+  id INT AUTO_INCREMENT PRIMARY KEY COMMENT 'Token record identifier',
+  user_id INT NOT NULL COMMENT 'Reference to oauth_users.id',
+  access_token TEXT COMMENT 'OAuth access token',
+  refresh_token TEXT COMMENT 'OAuth refresh token',
+  expires_at DATETIME COMMENT 'Access token expiration time',
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP COMMENT 'Record creation time',
+  FOREIGN KEY (user_id) REFERENCES oauth_users(id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='OAuth tokens';


### PR DESCRIPTION
## Summary
- call new `createOAuthTables` routine when backend starts
- export the table creation function for reuse
- note automatic table creation in the README

## Testing
- `git status --short`
